### PR TITLE
Secure password input added using curses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
  
  _Note: This application is a **code::blocks** project._
 
-Project Authors: [Utkarsh Gupta](https://www.github.com/utk-dev), [Ronit Chopada](https://www.github.com/ronit9586).
+Project Authors: [Utkarsh Gupta](https://www.github.com/utk-dev), [Ronit Chopada](https://www.github.com/ronit9586), [Arnav Dixit](https://github.com/arnav127)
 
 ## Introduction
 
@@ -26,7 +26,7 @@ Certain assumptions have been made to simplify the application:
 Linux executable is available [here](https://github.com/utk-dev/AttendanceV2/releases/tag/v0.1-alpha) (with instructions).
 Windows binary is available [here](https://github.com/utk-dev/AttendanceV2/releases/tag/v0.2-alpha) (with instructions).
 
-You can also compile this project yourself. It requires you to enable C++11 flag in your compiler (Currently only g++ and minGW have been tested). No external libraries are required for now.
+You can also compile this project yourself. It requires you to enable C++11 flag in your compiler (Currently only g++ and minGW have been tested). Curses library is used to securely take password inputs and it needs to be installed if compiling the code from source.
 
 
 ## Contribute

--- a/controller/view.cpp
+++ b/controller/view.cpp
@@ -69,9 +69,7 @@ bool logIn(USER& succ)
     std::cin >> user_id;
     //char *pa = getpass("Password: ");
     //std::string password(pa);
-    std::string password = "";
-    std::cout << "Password: ";
-    std::cin >> password;
+    std::string password = getpass("Password: ");
 
     std::string uidPrefix = user_id.substr(0,2);
 

--- a/controller/view.cpp
+++ b/controller/view.cpp
@@ -45,18 +45,20 @@
 #include <ncurses.h>
 #endif // __NCURSES__
 
-std::string getpass(const char *prompt)     //using the ncurses library
+std::string getpass(const char *prompt)     // Using the ncurses library
 {
-  printw(prompt);
-  noecho();  // disable character echoing
+  initscr();                    // Initialise ncurses screen
+  erase();                      // Erase anything leftover from previous outputs on the terminal
+  printw(prompt);               // Print the prompt to the screen
+  noecho();                     // Disable character echoing
 
-  char buff[32];
-  getnstr(buff,sizeof(buff));
+  char buff[200];               // Buffer size: 200
+  getnstr(buff,sizeof(buff));   // Take input from the user
 
-  echo(); // enable character echoing again
-  return buff;
+  echo();                       // Enable character echoing again
+  endwin();                     // Go back to the main screen
+  return std::string(buff);     // Explicit conversion
 }
-
 
 // #include <unistd.h> -- won't work on windows
 void generateClassReportByModerator();

--- a/controller/view.cpp
+++ b/controller/view.cpp
@@ -40,6 +40,24 @@
 #include <iomanip>
 #endif // __IOMANIP__
 
+#ifndef __NCURSES__
+#define __NCURSES__
+#include <ncurses.h>
+#endif // __NCURSES__
+
+std::string getpass(const char *prompt)     //using the ncurses library
+{
+  printw(prompt);
+  noecho();  // disable character echoing
+
+  char buff[32];
+  getnstr(buff,sizeof(buff));
+
+  echo(); // enable character echoing again
+  return buff;
+}
+
+
 // #include <unistd.h> -- won't work on windows
 void generateClassReportByModerator();
 


### PR DESCRIPTION
This addresses the issue #5 by using the curses library to take input without echoing to the screen. The binary can be linked statically thus removing the need to install the curses library if directly using the binary.